### PR TITLE
Prepare new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - xxxx-xx-xx
 
+## v1.8.0 - 2022-05-05
+
+### Added
+
+- New endpoint [#52](https://github.com/sharetribe/flex-integration-sdk-js/pull/52)
+  - `integrationSdk.listings.create(/* ... */)`
+
 ### Changed
 
 - Read response data as Transit only if Content-Type header is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-flex-integration-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Sharetribe Flex Integration API SDK for JavaScript",
   "main": "build/sharetribe-flex-integration-sdk-node.js",
   "scripts": {


### PR DESCRIPTION
## v1.8.0 - 2022-05-05

### Added

- New endpoint [#52](https://github.com/sharetribe/flex-integration-sdk-js/pull/52)
  - `integrationSdk.listings.create(/* ... */)`

### Changed

- Read response data as Transit only if Content-Type header is
  `application/transit+json`
  [#53](https://github.com/sharetribe/flex-integration-sdk-js/pull/53)