### PR TITLE
Concurrency limit defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "bottleneck": "^2.19.5",
     "env-paths": "^2.2.0",
     "form-data": "^3.0.0",
     "lodash": "^4.17.10",

--- a/src/integration_sdk.js
+++ b/src/integration_sdk.js
@@ -28,8 +28,8 @@ const defaultSdkConfig = {
   endpoints: [],
   adapter: null,
   version: 'v1',
-  httpAgent: new http.Agent({ keepAlive: true }),
-  httpsAgent: new https.Agent({ keepAlive: true }),
+  httpAgent: new http.Agent({ keepAlive: true, maxSockets: 10, maxTotalSockets: 10 }),
+  httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 10, maxTotalSockets: 10 }),
   transitVerbose: false,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 boxen@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"


### PR DESCRIPTION
Adds default configuration for the http(s) agents to limit the connection pool. This prevents clients from opening too many connections and consequently have too many concurrent requests. The default numbers are still subject to change.