### PR TITLE
Set default http agent max sockets

### DIFF
--- a/src/integration_sdk.js
+++ b/src/integration_sdk.js
@@ -28,8 +28,8 @@ const defaultSdkConfig = {
   endpoints: [],
   adapter: null,
   version: 'v1',
-  httpAgent: new http.Agent({ keepAlive: true }),
-  httpsAgent: new https.Agent({ keepAlive: true }),
+  httpAgent: new http.Agent({ keepAlive: true, maxSockets: 10, maxTotalSockets: 10 }),
+  httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 10, maxTotalSockets: 10 }),
   transitVerbose: false,
 };
 


### PR DESCRIPTION
Effectively, this sets maximum concurrent requests. The http connection pool will not grow larger than the given number. When the limit is reached, requests are internally queued, so no special handling in the client app is necessary.

The maxTotalSockets doesn't really matter in our case, where the agent is used for requests to a single host, but it's there for safety.