### PR TITLE
Add support for passing client-side rate limiters to the SDK

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,5 +14,6 @@
   * [Object query parameters](./object-query-parameters.md)
   * [Token store](./token-store.md)
   * [Keep-Alive](./keep-alive.md)
+  * [Rate limits](./rate-limits.md)
   * [Uploading images](./uploading-images.md)
 * [Developing SDK](./developing-sdk.md)

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -41,6 +41,15 @@ var integrationSdk = sharetribeIntegrationSdk.createInstance({
   httpAgent: httpAgent,
   httpsAgent: httpsAgent,
 
+  // For dev and demo marketplace environments, add query and command rate
+  // limiters:
+  queryLimiter: sharetribeIntegrationSdk.createRateLimiter(
+    sharetribeIntegrationSdk.util.devQueryLimiterConfig
+  ),
+  commandLimiter: sharetribeIntegrationSdk.createRateLimiter(
+    sharetribeIntegrationSdk.util.devCommandLimiterConfig
+  ),
+
   // Token store
   tokenStore: sharetribeIntegrationSdk.tokenStore.memoryStore(),
 

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -1,0 +1,97 @@
+# Rate limits
+
+The SDK can be configured to use client-side rate limits. This can help
+implementations stay within the API rate limits in dev and demo marketplace
+environments that the Integration API enforces. It is recommended to use
+client-side rate limits for production, as well.
+
+The SDK accepts two rate limiters as configuration: the `queryLimiter` applies
+to all API queries (i.e. reading data from the API) and the `commandLimiter`
+applies to all API commands (i.e. write operations that create, update data,
+etc).
+
+## Dev and demo marketplace environments
+
+**Example:**
+
+```js
+const sharetribeIntegrationSdk = require('sharetribe-flex-integration-sdk');
+
+queryLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+  sharetribeIntegrationSdk.util.devQueryLimiterConfig
+);
+
+commandLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+  sharetribeIntegrationSdk.util.devCommandLimiterConfig
+);
+
+const integrationSdk = sharetribeIntegrationSdk.createInstance({
+  clientId: "<your Client ID>",
+  clientSecret: "<your Client secret>",
+  queryLimiter: queryLimiter,
+  commandLimiter: commandLimiter,
+});
+```
+
+## Production marketplace environments
+
+**Example using recommended rate limits:**
+
+```js
+const sharetribeIntegrationSdk = require('sharetribe-flex-integration-sdk');
+
+queryLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+  sharetribeIntegrationSdk.util.prodQueryLimiterConfig
+);
+
+commandLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+  sharetribeIntegrationSdk.util.prodCommandLimiterConfig
+);
+
+const integrationSdk = sharetribeIntegrationSdk.createInstance({
+  clientId: "<your Client ID>",
+  clientSecret: "<your Client secret>",
+  queryLimiter: queryLimiter,
+  commandLimiter: commandLimiter,
+});
+```
+
+## Custom rate limits
+
+The `createRateLimiter()` constructor takes a config object with:
+
+- `bucketInitial`: initial token bucket size
+- `bucketIncreaseAmount`: number of tokens added to the bucket every
+  `bucketIncreaseInterval` milliseconds
+- `bucketIncreaseInterval`: every this many milliseconds a
+  `bucketIncreaseAmount` number of tokens are added to the bucket
+- `bucketMaximum`: maximum size of the bucket
+
+**Example:**
+
+```js
+const sharetribeIntegrationSdk = require('sharetribe-flex-integration-sdk');
+
+// 100 initial requests and then 2 requests per 500ms (i.e. 4 requests per second)
+queryLimiter = sharetribeIntegrationSdk.util.createRateLimiter({
+  bucketInitial: 100,
+  bucketIncreaseAmount: 2,
+  bucketIncreaseInterval: 500,
+  bucketMaximum: 100,
+});
+
+// 100 initial requests and then 1 request per second
+commandLimiter = sharetribeIntegrationSdk.util.createRateLimiter({
+  bucketInitial: 100,
+  bucketIncreaseAmount: 1,
+  bucketIncreaseInterval: 1000,
+  bucketMaximum: 100,
+});
+
+const integrationSdk = sharetribeIntegrationSdk.createInstance({
+  clientId: "<your Client ID>",
+  clientSecret: "<your Client secret>",
+  queryLimiter: queryLimiter,
+  commandLimiter: commandLimiter,
+});
+```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "bottleneck": "^2.19.5",
     "env-paths": "^2.2.0",
     "form-data": "^3.0.0",
     "lodash": "^4.17.10",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,12 @@ import SharetribeSdk from './integration_sdk';
 import * as types from './types';
 import memoryStore from './memory_store';
 import fileStore from './file_store';
-import { objectQueryString } from './utils';
+import {
+  objectQueryString,
+  createRateLimiter,
+  devQueryLimiterConfig,
+  devCommandLimiterConfig,
+} from './utils';
 
 const createInstance = config => new SharetribeSdk(config);
 
@@ -13,7 +18,12 @@ const tokenStore = {
 };
 
 // Export util functions
-const util = { objectQueryString };
+const util = {
+  objectQueryString,
+  createRateLimiter,
+  devQueryLimiterConfig,
+  devCommandLimiterConfig,
+};
 
 /* eslint-disable import/prefer-default-export */
 export { createInstance, types, tokenStore, util };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import {
   createRateLimiter,
   devQueryLimiterConfig,
   devCommandLimiterConfig,
+  prodQueryLimiterConfig,
+  prodCommandLimiterConfig,
 } from './utils';
 
 const createInstance = config => new SharetribeSdk(config);
@@ -23,6 +25,8 @@ const util = {
   createRateLimiter,
   devQueryLimiterConfig,
   devCommandLimiterConfig,
+  prodQueryLimiterConfig,
+  prodCommandLimiterConfig,
 };
 
 /* eslint-disable import/prefer-default-export */

--- a/src/integration_sdk.js
+++ b/src/integration_sdk.js
@@ -501,13 +501,14 @@ const validateSdkConfig = sdkConfig => {
   }
 
   /* global window, console */
-  if (sdkConfig.httpsAgent && (!sdkConfig.httpsAgent.maxSockets || sdkConfig.httpsAgent.maxSockets > 10)) {
+  if (
+    sdkConfig.httpsAgent &&
+    (!sdkConfig.httpsAgent.maxSockets || sdkConfig.httpsAgent.maxSockets > 10)
+  ) {
     console.warn(
       'The supplied httpsAgent does not restrict concurrent requests sufficiently and some requests may be rejected by the API.'
     );
-    console.warn(
-      'In order to avoid this, set the agent\'s `maxSockets` value to 10 or less.'
-    );
+    console.warn("In order to avoid this, set the agent's `maxSockets` value to 10 or less.");
   }
 
   const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';

--- a/src/integration_sdk.test.js
+++ b/src/integration_sdk.test.js
@@ -4,6 +4,7 @@ import { UUID, LatLng } from './types';
 import { createAdapter, defaultHandler } from './fake/adapter';
 import SharetribeSdk from './integration_sdk';
 import memoryStore from './memory_store';
+import { createRateLimiter } from './utils';
 
 const CLIENT_ID = '08ec69f6-d37e-414d-83eb-324e94afddf0';
 const CLIENT_SECRET = 'client-secret-value';
@@ -38,6 +39,12 @@ const createSdk = (config = {}) => {
   const defaults = {
     clientId: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
+    queryLimiter: createRateLimiter({
+      bucketInitial: 1,
+      bucketIncreaseInterval: 250,
+      bucketIncreaseAmount: 1,
+      bucketMaximum: 5,
+    }),
   };
 
   const sdkTokenStore = memoryStore();

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,6 +117,44 @@ export const devCommandLimiterConfig = {
 };
 
 /**
+   Recommended query rate limiter configuration for production marketplace environments.
+
+   Example:
+
+   ```
+   queryLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+     sharetribeIntegrationSdk.util.prodQueryLimiterConfig
+   );
+   ```
+*/
+export const prodQueryLimiterConfig = {
+  bucketInitial: 500,
+  // 8 requests per second, i.e. 480 requests per minute
+  bucketIncreaseInterval: 250,
+  bucketIncreaseAmount: 2,
+  bucketMaximum: 500,
+};
+
+/**
+   Recommended command rate limiter configuration for production marketplace environments.
+
+   Example:
+
+   ```
+   commandLimiter = sharetribeIntegrationSdk.util.createRateLimiter(
+     sharetribeIntegrationSdk.util.prodCommandLimiterConfig
+   );
+   ```
+*/
+export const prodCommandLimiterConfig = {
+  bucketInitial: 250,
+  // 4 requests per second, i.e. 240 requests per minute
+  bucketIncreaseInterval: 250,
+  bucketIncreaseAmount: 1,
+  bucketMaximum: 250,
+};
+
+/**
    Create a rate limiter suitable for use with the SDK as `queryLimiter` and `commandLimiter`.
    See also `devQueryLimiterConfig` and `devCommandLimiterConfig`.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 boxen@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"


### PR DESCRIPTION
Based on and against the branch of #57

Add support for passing in client-side rate limiters, using [bottleneck](https://www.npmjs.com/package/bottleneck). Separate query and command rate limiters can be set. Default remains that no rate limiters are in use.

- [x] TODO docs, example

```javascript
const flexIntegrationSdk = require('sharetribe-flex-integration-sdk');

// use suggested dev config
const commandLimiter = flexIntegrationSdk.util.createRateLimiter(
  flexIntegrationSdk.util.devCommandLimiterConfig
);

// custom config
// send 5 requests, then 1 request per second, refreshing request capacity at 1 request per second.
const queryLimiter = flexIntegrationSdk.util.createRateLimiter({
  bucketInitial: 5,
  bucketIncreaseInterval: 1000,
  bucketIncreaseAmount: 1,
  bucketMaximum: 10,
});

const integrationSdk = flexIntegrationSdk.createInstance({
  clientId: "...",
  clientSecret: "...",
  queryLimiter: queryLimiter,
  commandLimiter: commandLimiter,
});
```