### PR TITLE
Reflect release 1.12.0 in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `integrationSdk.files.query(/* ... */)`
   - `integrationSdk.file_attachments.query(/* ... */)`
 
+## [v1.12.0] - 2026-05-06
+
+### Added
+
 - New endpoint [#74](https://github.com/sharetribe/flex-integration-sdk-js/pull/74)
   - `integrationSdk.users.verifyEmail(/* ... */)`
 
@@ -184,6 +188,7 @@ See: https://www.npmjs.com/package/sharetribe-flex-integration-sdk
 
 [unreleased]: https://github.com/sharetribe/flex-integration-sdk-js/compare/v1.10.1...HEAD
 
+[v1.12.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.11.0...v1.12.0
 [v1.11.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.10.1...v1.11.0
 [v1.10.1]: https://github.com/sharetribe/flex-sdk-js/compare/v1.10.0...v1.10.1
 [v1.10.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.9.0...v1.10.0


### PR DESCRIPTION
This is the change in the changelog corresponding to release v1.12.0, which is made on a [release branch](https://github.com/sharetribe/flex-integration-sdk-js/tree/release-1.12.0).