### PR TITLE
Release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - xxxx-xx-xx
 
+## [v1.12.0] - 2026-05-06
+
 ### Added
 
 - New endpoint [#74](https://github.com/sharetribe/flex-integration-sdk-js/pull/74)
@@ -177,6 +179,7 @@ See: https://www.npmjs.com/package/sharetribe-flex-integration-sdk
 
 [unreleased]: https://github.com/sharetribe/flex-integration-sdk-js/compare/v1.10.1...HEAD
 
+[v1.12.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.11.0...v1.12.0
 [v1.11.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.10.1...v1.11.0
 [v1.10.1]: https://github.com/sharetribe/flex-sdk-js/compare/v1.10.0...v1.10.1
 [v1.10.0]: https://github.com/sharetribe/flex-sdk-js/compare/v1.9.0...v1.10.0

--- a/build/sharetribe-flex-integration-sdk-node.js
+++ b/build/sharetribe-flex-integration-sdk-node.js
@@ -8313,7 +8313,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_173__;
 
 "use strict";
 // Update this when updating package.json
-var sdkVersion = '1.12.0-beta.0';
+var sdkVersion = '1.12.0';
 /* harmony default export */ __webpack_exports__["a"] = (sdkVersion);
 
 /***/ }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-flex-integration-sdk",
-  "version": "1.12.0-beta.0",
+  "version": "1.12.0",
   "description": "Sharetribe Integration API SDK for JavaScript",
   "main": "build/sharetribe-flex-integration-sdk-node.js",
   "scripts": {

--- a/src/version.js
+++ b/src/version.js
@@ -1,3 +1,3 @@
 // Update this when updating package.json
-const sdkVersion = '1.12.0-beta.0';
+const sdkVersion = '1.12.0';
 export default sdkVersion;


### PR DESCRIPTION
Can be merged into master in order to have a clear lineage on master. Master currently does not contain a newer build (with the unreleased code), so there won't be need to re-build there.

I'll fix the changelog on master afterwards, as this merge would corrupt it slightly.