### PR TITLE
Support file uploads and downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - xxxx-xx-xx
 
+### Added
+
+- New endpoints and file helpers for uploading and downloading files [#80](https://github.com/sharetribe/flex-integration-sdk-js/pull/80)
+  - `integrationSdk.files.create(/* ... */)` - create a file record
+  - `integrationSdk.file_uploads.create(/* ... */)` - initiate a file upload to cloud storage
+  - `integrationSdk.file_downloads.create(/* ... */)` - create a file download URL
+  - `file.metadata(file)` - extract name, MIME type, and size from a File object for use with `integrationSdk.files.create()`
+  - `file.upload({ url, file, ... })` - upload a file directly to cloud storage using a URL from `integrationSdk.file_uploads.create()`
+
 ## [v1.13.0] - 2026-05-25
 
 ### Added

--- a/src/file.js
+++ b/src/file.js
@@ -1,0 +1,40 @@
+import axios from 'axios';
+
+/**
+   Extract file metadata needed for `sdk.files.create()`.
+ */
+export const metadata = file => {
+  if (!file) {
+    throw new Error('file is required');
+  }
+
+  return {
+    name: file.name,
+    mimeType: file.type || 'application/octet-stream',
+    size: file.size,
+  };
+};
+
+/**
+   Upload a file to a URL obtained from `sdk.fileUploads.create()`.
+
+   This performs a direct HTTP request to cloud storage. It does not go
+   through the SDK interceptor pipeline.
+ */
+export const upload = ({ method, url, headers, file, onUploadProgress }) => {
+  if (!url) {
+    throw new Error('url is required');
+  }
+
+  if (!file) {
+    throw new Error('file is required');
+  }
+
+  return axios.request({
+    method: method || 'PUT',
+    url,
+    headers: headers || {},
+    data: file,
+    onUploadProgress,
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import SharetribeSdk from './integration_sdk';
 import * as types from './types';
 import memoryStore from './memory_store';
 import fileStore from './file_store';
+import * as file from './file';
 import {
   objectQueryString,
   createRateLimiter,
@@ -30,4 +31,4 @@ const util = {
 };
 
 /* eslint-disable import/prefer-default-export */
-export { createInstance, types, tokenStore, util };
+export { createInstance, types, tokenStore, util, file };

--- a/src/integration_sdk.js
+++ b/src/integration_sdk.js
@@ -259,10 +259,31 @@ const endpointDefinitions = [
   },
   {
     apiName: 'integration_api',
+    path: 'files/create',
+    internal: false,
+    method: 'post',
+    interceptors: [new TransitResponse(), new TransitRequest()],
+  },
+  {
+    apiName: 'integration_api',
     path: 'files/query',
     internal: false,
     method: 'get',
     interceptors: [new TransitResponse()],
+  },
+  {
+    apiName: 'integration_api',
+    path: 'file_uploads/create',
+    internal: false,
+    method: 'post',
+    interceptors: [new TransitResponse(), new TransitRequest()],
+  },
+  {
+    apiName: 'integration_api',
+    path: 'file_downloads/create',
+    internal: false,
+    method: 'post',
+    interceptors: [new TransitResponse(), new TransitRequest()],
   },
   {
     apiName: 'integration_api',


### PR DESCRIPTION
Adds SDK support for the Integration API file capabilities.

New endpoints:
- sdk.files.create() — creates a file record (returns file in pendingUpload state)
- sdk.fileUploads.create() — generates a pre-signed upload URL
- sdk.fileDownloads.create() — generates a pre-signed download URL

New file helper module (exported as sharetribeIntegrationSdk.file):
- file.metadata(file) — extracts name, mimeType, and size from a File object for use with sdk.files.create()
- file.upload({ method, url, headers, file }) — performs the direct PUT upload using the pre-signed URL from sdk.fileUploads.create()
